### PR TITLE
Add jellyfish 0.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - {{ compiler('c') }}
     - pip
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,17 +15,18 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<36]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
   host:
     - {{ compiler('c') }}
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - python
 


### PR DESCRIPTION
`spyder 5.2.2` requires `jellyfish >=0.7`

Changelog: https://jamesturk.github.io/jellyfish/changelog/
License: https://github.com/jamesturk/jellyfish/blob/v0.9.0/LICENSE
Requirements: https://github.com/jamesturk/jellyfish/blob/v0.9.0/setup.py

Actions: 
1. Skip py<36
2. Add missing dependencies: setuptools, wheel
3. Remove req/build
4. Remove compiler from host