### PR TITLE
[PKG-2895] jellyfish 1.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
+  # maturin isn't available on s390x
+  skip: true  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,11 +17,12 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}  # [linux]
     - {{ compiler('rust') }}
   host:
     - pip
     - python
-    - maturin >=0.14,<2
+    - maturin
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
     - {{ compiler('rust') }}
   host:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   host:
     - pip
     - python
-    - maturin
+    - maturin >=0.14,<2
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ about:
   license: MIT
   license_file: LICENSE
   license_family: MIT
-  summary: A library for doing approximate and phonetic matching of strings.
+  summary: A library for doing approximate and phonetic matching of strings
   description: |
     jellyfish is a library for approximate & phonetic matching of strings.
   dev_url: https://github.com/jamesturk/jellyfish

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,31 +1,27 @@
 {% set name = "jellyfish" %}
-{% set version = "0.9.0" %}
-{% set bundle = "tar.gz" %}
-{% set hash = "40c9a2ffd8bd3016f7611d424120442f627f56d518a106847dc93f0ead6ad79a" %}
-
+{% set version = "1.0.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  sha256: {{ hash }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f664520189e3ae16e0b5fee21f19d15c8926e2320fd195ccc65d96390d9e9689
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
+    - {{ compiler('rust') }}
   host:
-    - {{ compiler('c') }}
     - pip
     - python
+    - maturin
   run:
     - python
 
@@ -39,12 +35,14 @@ test:
 
 about:
   home: https://github.com/jamesturk/jellyfish
-  license: BSD-2-Clause
+  license: MIT
   license_file: LICENSE
-  license_family: BSD
-  summary: a library for doing approximate and phonetic matching of strings.
+  license_family: MIT
+  summary: A library for doing approximate and phonetic matching of strings.
+  description: |
+    jellyfish is a library for approximate & phonetic matching of strings.
   dev_url: https://github.com/jamesturk/jellyfish
-  doc_url: https://jellyfish.readthedocs.io/en/latest/
+  doc_url: https://github.com/jamesturk/jellyfish
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: **no big changes from 0.9.0** https://github.com/jamesturk/jellyfish/blob/v1.0.1/docs/changelog.md
License: https://github.com/jamesturk/jellyfish/blob/v1.0.1/LICENSE
Requirements: https://github.com/jamesturk/jellyfish/blob/v1.0.1/pyproject.toml

Actions:
1. Clean up the recipe
2. Add rust compiler to build
3. Add maturin to host as a new build backend
4. Update license to MIT
5. Add license_family
6. Add description
7. Update doc_url

Notes:
- `recordlinkage 0.16` https://github.com/AnacondaRecipes/recordlinkage-feedstock/pull/2 requires it