### PR TITLE
jellyfish v1.0.1 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f664520189e3ae16e0b5fee21f19d15c8926e2320fd195ccc65d96390d9e9689
 
 build:
-  number: 0
+  number: 1
   # maturin isn't available on s390x
   skip: true  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv


### PR DESCRIPTION
jellyfish v1.0.1 rebuild

**Destination channel:** defaults

### Links

- [PKG-6204](https://anaconda.atlassian.net/browse/PKG-6204) 

### Explanation of changes:

- Bump build number and build with rust 1.82

Rust < 1.81 was affected by CVE-2024-43402.  

[PKG-6204]: https://anaconda.atlassian.net/browse/PKG-6204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ