### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f664520189e3ae16e0b5fee21f19d15c8926e2320fd195ccc65d96390d9e9689
 
 build:
-  number: 1
+  number: 2
   # maturin isn't available on s390x
   skip: true  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jellyfish" %}
-{% set version = "1.0.1" %}
+{% set version = "1.1.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f664520189e3ae16e0b5fee21f19d15c8926e2320fd195ccc65d96390d9e9689
+  sha256: 650ba1ddabd716499f85fae0e1f3fa3e6532a69b68985d9294e86a1e04f08f9f
 
 build:
-  number: 2
+  number: 0
   # maturin isn't available on s390x
-  skip: true  # [py<37 or s390x]
+  skip: true  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
   host:
     - pip
     - python
-    - maturin
+    - maturin >=0.14,<2
   run:
     - python
 


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

update to 1.1.3
https://github.com/jamesturk/jellyfish/tree/v1.1.3